### PR TITLE
Fix cache purge between compiler.run calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
       var originalPurge = compiler.inputFileSystem.purge;
 
       compiler.inputFileSystem.purge = function() {
-        originalPurge.call(this, arguments);
+        originalPurge.apply(this, arguments);
         if (this._virtualFiles) {
           Object.keys(this._virtualFiles).forEach(function(file) {
             var data = this._virtualFiles[file];


### PR DESCRIPTION
This was causing webpack file system cache to be stale between multiple calls to `compiler.run()`