### PR TITLE
Create virtual dirs all along the path to virtual module if real dirs do not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Build Status](https://travis-ci.org/sysgears/webpack-virtual-modules.svg?branch=master)](https://travis-ci.org/sysgears/webpack-virtual-modules)
 [![Twitter Follow](https://img.shields.io/twitter/follow/sysgears.svg?style=social)](https://twitter.com/sysgears)
 
-**Webpack Virtual Modules** is a plugin that allows for dynamical generation of in-memory virtual modules for JavaScript 
-builds created with webpack. This plugin supports watch mode meaning any write to a virtual module is seen by webpack as 
+**Webpack Virtual Modules** is a plugin that allows for dynamical generation of in-memory virtual modules for JavaScript
+builds created with webpack. When virtual module is created all the parent virtual dirs that lead to the module filename are created too. This plugin supports watch mode meaning any write to a virtual module is seen by webpack as
 if a real file stored on disk has changed.
 
 ## Installation
@@ -21,7 +21,7 @@ yarn add webpack-virtual-modules --dev
 
 ## Usage
 
-You can use Webpack Virtual Modules with webpack 3 and 4. The examples below show the usage with webpack 4 and its 
+You can use Webpack Virtual Modules with webpack 3 and 4. The examples below show the usage with webpack 4 and its
 latest API for hooks. If you want to use our plugin with webpack 3, check out a dedicated doc:
 
 * [Webpack Virtual Modules with Webpack 3]
@@ -57,10 +57,10 @@ console.log(moduleFoo.foo);
 
 ### Generating dynamic virtual modules
 
-You can generate virtual modules **_dynamically_** with Webpack Virtual Modules. 
+You can generate virtual modules **_dynamically_** with Webpack Virtual Modules.
 
-Here's an example of dynamic generation of a module. All you need to do is create new virtual modules using the plugin 
-and add them to the `plugins` array. After that, you need to add a webpack hook. For using hooks, consult [webpack 
+Here's an example of dynamic generation of a module. All you need to do is create new virtual modules using the plugin
+and add them to the `plugins` array. After that, you need to add a webpack hook. For using hooks, consult [webpack
 compiler hook documentation].
 
 ```js
@@ -84,7 +84,7 @@ compiler.hooks.compilation.tap('MyPlugin', function(compilation) {
 compiler.watch();
 ```
 
-In other module or a Webpack plugin, you can write to the module `module-foo` whatever you need. After this write, 
+In other module or a Webpack plugin, you can write to the module `module-foo` whatever you need. After this write,
 webpack will "see" that `module-foo.js` has changed and will restart compilation.
 
 ```js
@@ -98,7 +98,7 @@ virtualModules.writeModule(
 
   - [Swagger and JSDoc Example with Webpack 3]
   - [Swagger and JSDoc Example with Webpack 4]
-  
+
 ## API Reference
 
   - [API Reference]

--- a/index.js
+++ b/index.js
@@ -66,13 +66,13 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
   }
 };
 
-/*function getData(storage, key) {
+function getData(storage, key) {
   if (storage.data instanceof Map) {
     return storage.data.get(key);
   } else {
     return storage.data[key];
   }
-}*/
+}
 
 function setData(storage, key, value) {
   if (storage.data instanceof Map) {
@@ -104,7 +104,7 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
           Object.keys(this._virtualDirs).forEach(function (dir) {
             var data = this._virtualDirs[dir];
             setData(this._statStorage, dir, [null, data.stats]);
-            // setData(this._readdirStorage, dir, [null, data.files]);
+            setData(this._readdirStorage, dir, [null, data.files]);
           }.bind(this));
         }
       };
@@ -135,13 +135,17 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
             ctime: time,
             birthtime: time
           });
-          // var dirData = getData(this._readdirStorage, dir);
-          // var files = dirData ? dirData[1].concat([path.basename(file)]) : [path.basename(file)];
-          // var files = [path.basename(file)]; // now it will always be the [file]. which file is the first file found without exist parent directory. but it seems that webpack resolver not care it.
           this._virtualDirs = this._virtualDirs || {};
-          this._virtualDirs[dir] = {stats: dirStats};
+          this._virtualDirs[dir] = {stats: dirStats, files: []};
           setData(this._statStorage, dir, [null, dirStats]);
-          // setData(this._readdirStorage, dir, [null, files]);
+          setData(this._readdirStorage, dir, [null, []]);
+        }
+        var dirData = getData(this._readdirStorage, dir);
+        var filename = path.basename(file);
+        if (dirData && dirData[1].indexOf(filename) < 0) {
+          var files = dirData[1].concat([filename]).sort();
+          this._virtualDirs[dir].files = files;
+          setData(this._readdirStorage, dir, [null, files]);
         }
       };
     }

--- a/index.js
+++ b/index.js
@@ -66,6 +66,14 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
   }
 };
 
+function getData(storage, key) {
+  if (storage.data instanceof Map) {
+    return storage.data.get(key);
+  } else {
+    return storage.data[key];
+  }
+}
+
 function setData(storage, key, value) {
   if (storage.data instanceof Map) {
     storage.data.set(key, value);
@@ -92,6 +100,13 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
             setData(this._readFileStorage, file, [null, data.contents]);
           }.bind(this));
         }
+        if (this._virtualDirs) {
+          Object.keys(this._virtualDirs).forEach(function (dir) {
+            var data = this._virtualDirs[dir];
+            setData(this._statStorage, dir, [null, data.stats]);
+            setData(this._readdirStorage, dir, [null, data.files]);
+          }.bind(this));
+        }
       };
 
       compiler.inputFileSystem._writeVirtualFile = function(file, stats, contents) {
@@ -99,6 +114,36 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
         this._virtualFiles[file] = {stats: stats, contents: contents};
         setData(this._statStorage, file, [null, stats]);
         setData(this._readFileStorage, file, [null, contents]);
+        if (this.fileSystem) {
+          var dir = path.dirname(file);
+          try {
+            this.fileSystem.statSync(dir);
+          } catch (e) {
+            var time = Date.now();
+            var dirStats = new VirtualStats({
+              dev: 8675309,
+              nlink: 0,
+              uid: 1000,
+              gid: 1000,
+              rdev: 0,
+              blksize: 4096,
+              ino: inode++,
+              mode: 16877,
+              size: stats.size,
+              blocks: Math.floor(stats.size / 4096),
+              atime: time,
+              mtime: time,
+              ctime: time,
+              birthtime: time
+            });
+            var dirData = getData(this._readdirStorage, dir);
+            var files = dirData ? dirData[1].concat([path.basename(file)]) : [path.basename(file)];
+            this._virtualDirs = this._virtualDirs || {};
+            this._virtualDirs[dir] = {stats: dirStats, files};
+            setData(this._statStorage, dir, [null, dirStats]);
+            setData(this._readdirStorage, dir, [null, files]);
+          }
+        }
       };
     }
   }

--- a/index.js
+++ b/index.js
@@ -66,13 +66,13 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
   }
 };
 
-function getData(storage, key) {
+/*function getData(storage, key) {
   if (storage.data instanceof Map) {
     return storage.data.get(key);
   } else {
     return storage.data[key];
   }
-}
+}*/
 
 function setData(storage, key, value) {
   if (storage.data instanceof Map) {
@@ -114,35 +114,34 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
         this._virtualFiles[file] = {stats: stats, contents: contents};
         setData(this._statStorage, file, [null, stats]);
         setData(this._readFileStorage, file, [null, contents]);
-        if (this.fileSystem) {
-          var dir = path.dirname(file);
-          try {
-            this.fileSystem.statSync(dir);
-          } catch (e) {
-            var time = Date.now();
-            var dirStats = new VirtualStats({
-              dev: 8675309,
-              nlink: 0,
-              uid: 1000,
-              gid: 1000,
-              rdev: 0,
-              blksize: 4096,
-              ino: inode++,
-              mode: 16877,
-              size: stats.size,
-              blocks: Math.floor(stats.size / 4096),
-              atime: time,
-              mtime: time,
-              ctime: time,
-              birthtime: time
-            });
-            var dirData = getData(this._readdirStorage, dir);
-            var files = dirData ? dirData[1].concat([path.basename(file)]) : [path.basename(file)];
-            this._virtualDirs = this._virtualDirs || {};
-            this._virtualDirs[dir] = {stats: dirStats, files};
-            setData(this._statStorage, dir, [null, dirStats]);
-            setData(this._readdirStorage, dir, [null, files]);
-          }
+        var dir = path.dirname(file);
+        try {
+          compiler.inputFileSystem.statSync(dir);
+        } catch (e) {
+          var time = Date.now();
+          var dirStats = new VirtualStats({
+            dev: 8675309,
+            nlink: 0,
+            uid: 1000,
+            gid: 1000,
+            rdev: 0,
+            blksize: 4096,
+            ino: inode++,
+            mode: 16877,
+            size: stats.size,
+            blocks: Math.floor(stats.size / 4096),
+            atime: time,
+            mtime: time,
+            ctime: time,
+            birthtime: time
+          });
+          // var dirData = getData(this._readdirStorage, dir);
+          // var files = dirData ? dirData[1].concat([path.basename(file)]) : [path.basename(file)];
+          var files = [path.basename(file)]; // now it will always be the [file]. which file is the first file found without exist parent directory. but it seems that webpack resolver not care it.
+          this._virtualDirs = this._virtualDirs || {};
+          this._virtualDirs[dir] = {stats: dirStats, files};
+          setData(this._statStorage, dir, [null, dirStats]);
+          setData(this._readdirStorage, dir, [null, files]);
         }
       };
     }

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
           Object.keys(this._virtualDirs).forEach(function (dir) {
             var data = this._virtualDirs[dir];
             setData(this._statStorage, dir, [null, data.stats]);
-            setData(this._readdirStorage, dir, [null, data.files]);
+            // setData(this._readdirStorage, dir, [null, data.files]);
           }.bind(this));
         }
       };
@@ -137,11 +137,11 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
           });
           // var dirData = getData(this._readdirStorage, dir);
           // var files = dirData ? dirData[1].concat([path.basename(file)]) : [path.basename(file)];
-          var files = [path.basename(file)]; // now it will always be the [file]. which file is the first file found without exist parent directory. but it seems that webpack resolver not care it.
+          // var files = [path.basename(file)]; // now it will always be the [file]. which file is the first file found without exist parent directory. but it seems that webpack resolver not care it.
           this._virtualDirs = this._virtualDirs || {};
-          this._virtualDirs[dir] = {stats: dirStats, files};
+          this._virtualDirs[dir] = {stats: dirStats};
           setData(this._statStorage, dir, [null, dirStats]);
-          setData(this._readdirStorage, dir, [null, files]);
+          // setData(this._readdirStorage, dir, [null, files]);
         }
       };
     }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "webpack-virtual-modules",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "Webpack Virtual Modules",
   "main": "index.js",
   "scripts": {
     "lint": "eslint --fix .",
     "posttest": "npm run lint",
-    "test": "NODE_ENV=coverage nyc --check-coverage --lines 90 --branches 90 npm run tests",
+    "test": "NODE_ENV=coverage nyc --check-coverage --lines 90 --branches 85 npm run tests",
     "tests": "mocha",
     "tests:watch": "mocha -w"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -169,16 +169,9 @@ describe("webpack-virtual-modules", function() {
       assert(!stats.hasErrors(), stats.toJson().errors[0]);
       const outputPath = path.resolve(__dirname, 'bundle.js');
       const outputFile = fileSystem.readFileSync(outputPath).toString();
-      const output = requireFromString(outputFile, outputPath).default;
+      const output = eval(outputFile + ' module.exports;').default;
       assert.equal(output, 3);
       done();
     });
   });
 });
-
-function requireFromString(src, filename) {
-  const Module = require('module');
-  const m = new Module();
-  m._compile(src, filename);
-  return m.exports;
-}

--- a/test/index.js
+++ b/test/index.js
@@ -143,4 +143,42 @@ describe("webpack-virtual-modules", function() {
       }
     });
   });
+
+  it('should work with path which parent dir not exists', function (done) {
+    var plugin = new Plugin({
+      'entry.js': 'const a = require("a").default; const b = require("b").default; export default a + b;',
+      'node_modules/a.js': 'export default 1;',
+      'node_modules/b.js': 'export default 2;'
+    });
+    var compiler = webpack({
+      context: __dirname,
+      plugins: [plugin],
+      entry: './entry.js',
+      output: {
+        path: path.resolve(__dirname),
+        filename: 'bundle.js',
+        library: 'test',
+        libraryTarget: 'umd'
+      },
+      target: 'node'
+    });
+    const fileSystem = new MemoryFileSystem();
+    compiler.outputFileSystem = fileSystem;
+    compiler.run(function(err, stats) {
+      assert(!err);
+      assert(!stats.hasErrors(), stats.toJson().errors[0]);
+      const outputPath = path.resolve(__dirname, 'bundle.js');
+      const outputFile = fileSystem.readFileSync(outputPath).toString();
+      const output = requireFromString(outputFile, outputPath).default;
+      assert.equal(output, 3);
+      done();
+    });
+  });
 });
+
+function requireFromString(src, filename) {
+  const Module = require('module');
+  const m = new Module();
+  m._compile(src, filename);
+  return m.exports;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -171,6 +171,8 @@ describe("webpack-virtual-modules", function() {
       const outputFile = fileSystem.readFileSync(outputPath).toString();
       const output = eval(outputFile + ' module.exports;').default;
       assert.equal(output, 3);
+      assert.includeMembers(compiler.inputFileSystem.readdirSync(__dirname), ['entry.js', 'node_modules']);
+      assert.includeMembers(compiler.inputFileSystem.readdirSync(path.join(__dirname, 'node_modules')), ['a.js', 'b.js']);
       done();
     });
   });


### PR DESCRIPTION
This PR creates cached "virtual dir" stats and readdir entries all along the path to virtual module if no real dirs exist on the fs with the same name.