### PR TITLE
:ok_hand: expose date instances to virtualstats time properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 
   var len = contents ? contents.length : 0;
   var time = Date.now();
+  var date = new Date(time);
 
   var stats = new VirtualStats({
     dev: 8675309,
@@ -37,10 +38,10 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
     mode: 33188,
     size: len,
     blocks: Math.floor(len / 4096),
-    atime: time,
-    mtime: time,
-    ctime: time,
-    birthtime: time
+    atime: date,
+    mtime: date,
+    ctime: date,
+    birthtime: date
   });
   var modulePath = getModulePath(filePath, self._compiler);
 


### PR DESCRIPTION
I had this issue : __TypeError: stats.mtime.getTime is not a function__
Related to : 
- https://github.com/webpack/enhanced-resolve/blob/master/lib/CachedInputFileSystem.js#L97
- https://github.com/webpack-contrib/cache-loader/blob/master/src/index.js#L97
- https://github.com/webpack-contrib/cache-loader/blob/master/src/index.js#L312

> It seems that `stats.mtime` should be a `Date` instance, rather than a `number`…

---

Node.js File System: https://nodejs.org/api/fs.html#fs_stats_atime
Similar bug: https://github.com/pksunkara/vue-builder-webpack-plugin/issues/22