### PR TITLE
Add AngularCompilerPlugin support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-virtual-modules",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Webpack Virtual Modules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

AngularCompilerPlugin decorates webpack's inputFileSystem with its own wrapper class.

**How did you fix it?**

Fortunately this plugin exposes original inputFileSystem inside `_inputFileSystem` field. I've added checking for this field and using it if it is found.

Fixes: #46 