### PR TITLE
Fix rebuilding all virtual files on any change

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,6 +188,8 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
         this._virtualFiles[file] = {stats: stats, contents: contents};
         setData(statStorage, file, createWebpackData(stats));
         setData(fileStorage, file, createWebpackData(contents));
+        self._compiler.fileTimestamps instanceof Map &&
+          self._compiler.fileTimestamps.set(file, +stats.mtime);
         var segments = file.split(/[\\/]/);
         var count = segments.length - 1;
         var minCount = segments[0] ? 1 : 0;
@@ -243,6 +245,13 @@ VirtualModulesPlugin.prototype.apply = function(compiler) {
 
   var watchRunHook = function(watcher, callback) {
     self._watcher = watcher.compiler || watcher;
+    const virtualFiles = self._compiler.inputFileSystem._virtualFiles;
+    if (virtualFiles) {
+      Object.keys(virtualFiles).forEach(function(file) {
+        self._compiler.fileTimestamps instanceof Map &&
+          self._compiler.fileTimestamps.set(file, +virtualFiles[file].stats.mtime);
+      });
+    }
     callback();
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

This fixes https://github.com/sysgears/webpack-virtual-modules/issues/65

**How did you fix it?**

Barely fixed it.
I feel like there should be a better way to implement this sort of change, but at least I've found what caused rebuilds.
It was the abscence of virtual file timestamps in `compiler.fileTimestamps`, causing webpack to always reload virtual files.