### PR TITLE
Fix rebuilding of all virtual modules on any change for webpack 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-virtual-modules",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Webpack Virtual Modules",
   "main": "src/index.ts",
   "scripts": {

--- a/src/__tests__/count-loader.js
+++ b/src/__tests__/count-loader.js
@@ -1,0 +1,13 @@
+let modulesBuilt = 0;
+
+module.exports = function(source) {
+  this.cacheable(true);
+  const callback = this.async();
+  modulesBuilt++;
+  callback(null, source);
+}
+
+module.exports.loader = __filename;
+module.exports.modulesBuilt = function() {
+  return modulesBuilt;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,6 +259,13 @@ class VirtualModulesPlugin {
 
     const watchRunHook = (watcher, callback) => {
       this._watcher = watcher.compiler || watcher;
+      const virtualFiles = (compiler as any).inputFileSystem._virtualFiles;
+      const fts = compiler.fileTimestamps as any;
+      if (virtualFiles && fts && typeof fts.set === 'function') {
+        Object.keys(virtualFiles).forEach((file) => {
+          fts.set(file, +virtualFiles[file].stats.mtime);
+        });
+      }
       callback();
     };
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Test lets us know more about virtual modules getting reloaded and rebuilt.

**How did you fix it?**

The problem of reloading and rebuilding every virtual module on any change is not fixed yet.