### PR TITLE
Bugfix: watchRunHook race condition periodically breaks change detection triggered by writeModule  (webpack@4)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,7 @@ class VirtualModulesPlugin {
       birthtime: date,
     });
     const modulePath = getModulePath(filePath, this._compiler);
+    const fts = this._compiler.fileTimestamps as any;
 
     if (process.env.DEBUG)
       // eslint-disable-next-line no-console
@@ -166,6 +167,9 @@ class VirtualModulesPlugin {
           if (process.env.DEBUG)
             // eslint-disable-next-line no-console
             console.log(this._compiler.name, 'Emit file change:', modulePath, time);
+
+          if (fts && typeof fts.set === 'function' && fts.get(modulePath)) fts.set(modulePath, time);
+
           delete fileWatcher.directoryWatcher._cachedTimeInfoEntries;
           fileWatcher.directoryWatcher.setFileTime(filePath, time, false, false, null);
           fileWatcher.emit('change', time, null);


### PR DESCRIPTION

**What's the problem this PR addresses?**

Issue likely introduced by #66 whereby custom compiler hooks (eg `watchRun`, `compilation`) which implement a dynamic `writeModule` call will periodically (~half the time in the case of my `watchRun`) fail to trigger a rebuild of the virtual module. For me this didn't affect production builds, but presented when using the webpack dev server.

https://github.com/sysgears/webpack-virtual-modules/blob/607291235d0f935caa728925dd550daa891df2b6/src/index.ts#L266

Above line will preserve the virtualFile's mtime, which makes sense in preventing **every** change from rebuilding **every** module, but also prevents `writeModule` calls from correctly triggering the necessary rebuilds down the line. 

More specifically,  the failure happens due to a check here:
https://github.com/webpack/webpack/blob/5d3004cccd3dd5af2721c39a7a8a27b12b3d0c19/lib/NormalModule.js#L533

Where `timestamp` is actually the last compilation's virtualFile's mtime.

**How did you fix it?**

While not the ideal/perfect solution, this change forces an update to the `compiler.fileTimestamps` reference of a `virtualModule` on which `writeModule` was called. As I see it: if you call `writeModule` you necessarily are "touching" the file (updating mtime)
