### PR TITLE
include type definitions in exported files

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "webpack": "^5.3.0"
   },
   "files": [
-    "*.js"
+    "*.js",
+    "*.d.ts"
   ],
   "publishConfig": {
     "main": "lib/index.js",


### PR DESCRIPTION
This should fix the issue where types are missing in the final package

**What's the problem this PR addresses?**

should address #87

**How did you fix it?**

Add `d.ts` files to exported files of the package
