### PR TITLE
Check WVM_DEBUG ENV variable to do console logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ class VirtualModulesPlugin {
     });
     const modulePath = getModulePath(filePath, this._compiler);
 
-    if (process.env.DEBUG)
+    if (process.env.WVM_DEBUG)
       // eslint-disable-next-line no-console
       console.log(this._compiler.name, 'Write virtual module:', modulePath, contents);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Problems with noise generated by this plugin while trying to use the [debug](https://www.npmjs.com/package/debug) js package.

**How did you fix it?**

Instead of checking `process.env.DEBUG` before doing a `console.log` the code will now check `process.env.WVM_DEBUG`.
