### PR TITLE
Eliminate redundant rebuilds under watch mode in Webpack 5

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,44 @@
+// I cannot write clean TypeScript :(
+
+import type { Watchpack } from 'watchpack';
+
+declare interface FileSystemInfoEntry {
+  safeTime: number;
+  timestamp?: number;
+}
+
+export declare interface Watcher {
+  close: () => void;
+  pause: () => void;
+  getAggregatedChanges?: () => Set<string>;
+  getAggregatedRemovals?: () => Set<string>;
+  getFileTimeInfoEntries: () => Map<string, FileSystemInfoEntry | 'ignore'>;
+  getContextTimeInfoEntries: () => Map<string, FileSystemInfoEntry | 'ignore'>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+declare interface WatchOptions {}
+
+declare interface WatchFileSystem {
+  watch: (
+    files: Iterable<string>,
+    directories: Iterable<string>,
+    missing: Iterable<string>,
+    startTime: number,
+    options: WatchOptions,
+    callback: (
+      arg0: undefined | Error,
+      arg1: Map<string, FileSystemInfoEntry | 'ignore'>,
+      arg2: Map<string, FileSystemInfoEntry | 'ignore'>,
+      arg3: Set<string>,
+      arg4: Set<string>
+    ) => void,
+    callbackUndelayed: (arg0: string, arg1: number) => void
+  ) => Watcher;
+}
+
+export declare interface NodeWatchFileSystem extends WatchFileSystem {
+  inputFileSystem: any;
+  watcherOptions: object;
+  watcher: Watchpack;
+}

--- a/src/wfs.ts
+++ b/src/wfs.ts
@@ -1,0 +1,53 @@
+import type { Watcher, NodeWatchFileSystem } from './types';
+
+export function createFilteredWatchFileSystem(wfs: NodeWatchFileSystem): typeof wfs {
+  function _wfsWatch(this: NodeWatchFileSystem, ...args: any[]): Watcher {
+    const ret = this.watch.apply(this, args as any);
+
+    // patch the watcher's only listener of the "aggregated" event
+    const listenersOfAggregated = this.watcher.rawListeners('aggregated');
+    if (listenersOfAggregated.length !== 1) {
+      throw new Error(
+        '[webpack-virtual-modules] Failed to patch NodeWatchFileSystem: Number of listeners should be exactly 1.'
+      );
+    }
+
+    const originalListener = listenersOfAggregated[0];
+    this.watcher.off('aggregated', originalListener);
+
+    const needToInvalidate = (changes, removals) => {
+      const virtualFiles = this.inputFileSystem && this.inputFileSystem._virtualFiles;
+      if (virtualFiles) {
+        // Changes will not be filtered. Not sure whether it should be intended...
+        Object.keys(virtualFiles).forEach((path) => {
+          removals.delete(path);
+        });
+      }
+      return changes.size + removals.size > 0;
+    };
+
+    const processAggregated = (changes, removals) => {
+      if (!needToInvalidate(changes, removals)) {
+        this.watcher.once('aggregated', processAggregated);
+        return;
+      }
+
+      originalListener(changes, removals);
+    };
+
+    this.watcher.once('aggregated', processAggregated);
+
+    return ret;
+  }
+
+  const wfsWatch = _wfsWatch.bind(wfs);
+
+  return new Proxy(wfs, {
+    get(target, key) {
+      if (key === 'watch') {
+        return wfsWatch;
+      }
+      return target[key];
+    },
+  });
+}


### PR DESCRIPTION
**What's the problem this PR addresses?**

Try to eliminate extra rebuilds under watch mode, as issue #121 points out.

**How did you fix it?**

By making a proxy through `WatchFileSystem`, patching its `aggregated` listener with care and filter out virtual files. This way, no rebuild is triggered when the change only includes virtual files' false removals. For details, see https://github.com/sysgears/webpack-virtual-modules/issues/121#issuecomment-1000298229.
