### PR TITLE
fix issue: Incorrectly used fileWatcher

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,10 @@ class VirtualModulesPlugin {
         finalWatchFileSystem.watcher.fileWatchers instanceof Map
           ? Array.from(finalWatchFileSystem.watcher.fileWatchers.values())
           : finalWatchFileSystem.watcher.fileWatchers;
-      for (const fileWatcher of fileWatchers) {
+      for (let fileWatcher of fileWatchers) {
+        if ('watcher' in fileWatcher) {
+          fileWatcher = fileWatcher.watcher;
+        }
         if (fileWatcher.path === modulePath) {
           if (process.env.DEBUG)
             // eslint-disable-next-line no-console


### PR DESCRIPTION
**What's the problem this PR addresses?**
#155 

**How did you fix it?**
The properties of `fileWatcher` variable is changed, use `fileWatcher.watcher` when `watcher` exists in it.

