### PR TITLE
Stop the infinite loop caused from writing time to directoryWatcher

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,6 @@ class VirtualModulesPlugin {
             // eslint-disable-next-line no-console
             console.log(this._compiler.name, 'Emit file change:', modulePath, time);
           delete fileWatcher.directoryWatcher._cachedTimeInfoEntries;
-          fileWatcher.directoryWatcher.setFileTime(filePath, time, false, false, null);
           fileWatcher.emit('change', time, null);
         }
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**
- Fixes issue #83 
- There is an infinite loop that is caused by fileWatcher constantly writing the time

**How did you fix it?**
- Removing the line that sets time for directoryWatcher, the next line also emits change with the timstamp
- Tested with changing a file, the webpack still compiles so files are being watched.


We see this infinite loop issue when using the API on our end outside of the example app, therefore we would love to get this fixed. 
