### PR TITLE
fix: webpack compiling twice in watch mode

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -222,6 +222,44 @@ describe('webpack-virtual-modules', () => {
     });
   });
 
+  it('should compile once in watch mode', async () => {
+    const plugin = new Plugin({
+      'entry.js': 'console.log("build once");',
+    });
+    const compiler = webpack({
+      entry: './entry.js',
+      plugins: [plugin],
+    });
+    const fn = jest.fn(() => {
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+    return new Promise((resolve) => {
+      const watcher = compiler.watch({}, fn);
+      setTimeout(() => {
+        watcher.close(resolve);
+      }, 500);
+    });
+  });
+
+  it('should compile once in build mode', async () => {
+    const plugin = new Plugin({
+      'entry.js': 'console.log("build once");',
+    });
+    const compiler = webpack({
+      entry: './entry.js',
+      plugins: [plugin],
+    });
+    const fn = jest.fn(() => {
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+    return new Promise<void>((resolve) => {
+      compiler.run(fn);
+      setTimeout(() => {
+        resolve();
+      }, 500);
+    });
+  });
+
   const version = (webpack.version && parseInt(webpack.version.split('.')[0])) || 0;
 
   (version >= 4 ? it : it.skip)('should NOT rebuild all virtual modules on any change', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,47 +198,7 @@ class VirtualModulesPlugin {
           }
         };
 
-        const originalReaddir = finalInputFileSystem.fileSystem.readdir;
-        finalInputFileSystem.fileSystem.readdir = (path, opts, callback) => {
-          const args = [path];
-          if (typeof opts === 'function') {
-            callback = opts;
-          } else {
-            args.push(opts);
-          }
-          return originalReaddir.apply(finalInputFileSystem.fileSystem, [
-            ...args,
-            (err1: any, files1 = []) => {
-              finalInputFileSystem.readdir.apply(finalInputFileSystem, [
-                ...args,
-                (err2: any, files2 = []) => {
-                  callback.apply(this, [err2 || err1, Array.from(new Set(files1.concat(files2)))]);
-                },
-              ]);
-            },
-          ]);
-        };
-
-        const originalLstat = finalInputFileSystem.fileSystem.lstat;
-        finalInputFileSystem.fileSystem.lstat = (path, opts, callback) => {
-          const args = [path];
-          if (typeof opts === 'function') {
-            callback = opts;
-          } else {
-            args.push(opts);
-          }
-          return originalLstat.apply(finalInputFileSystem.fileSystem, [
-            ...args,
-            (err1: any, stats1 = {}) => {
-              finalInputFileSystem.lstat.apply(finalInputFileSystem, [
-                ...args,
-                (err2: any, stats2 = {}) => {
-                  callback.apply(this, [err2 || err1, Object.assign(stats1, stats2)]);
-                },
-              ]);
-            },
-          ]);
-        };
+        finalInputFileSystem.fileSystem.readdir = finalInputFileSystem.readdir;
 
         finalInputFileSystem._writeVirtualFile = (file, stats, contents) => {
           const statStorage = getStatStorage(finalInputFileSystem);


### PR DESCRIPTION
**What's the problem this PR addresses?**

```js
const path = require("path");
const webpack = require("webpack");
const VirtualModulesPlugin = require("webpack-virtual-modules");

const virtualModules = new VirtualModulesPlugin({
  [path.join(__dirname, "src/_service_scripts_.js")]: `currentPath = 'a.js';
  `,
});

const compiler = webpack({
  entry: "./src/_service_scripts_",
  mode: "production",
  output: {
    filename: "bundle.js",
    path: __dirname + "/dist",
  },
  plugins: [virtualModules],
});

compiler.watch({ aggregateTimeout: 100 }, function (err, stats) {
  if (err) {
    console.error(err);
  } else {
    console.log(
      stats.toString({  colors: true, chunks: false, modules: false, assets: true })
    );
  }
});
```
When using webpack-virtual-modules, the same compilation will be triggered twice
```
➜ webpack-demo $ node ./webpack.config.js
asset bundle.js 112 KiB [compared for emit] (name: main)
webpack 5.88.2 compiled successfully in 472 ms
asset bundle.js 112 KiB [emitted] (name: main)
webpack 5.88.2 compiled successfully in 173 ms
```

**How did you fix it?**

hook `finalInputFileSystem.fileSystem.readdir` and `finalInputFileSystem.fileSystem.lstat`
