### PR TITLE
chore: case check compile run times

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -222,6 +222,44 @@ describe('webpack-virtual-modules', () => {
     });
   });
 
+  it('should compile once in watch mode', async () => {
+    const plugin = new Plugin({
+      'entry.js': 'console.log("build once");',
+    });
+    const compiler = webpack({
+      entry: './entry.js',
+      plugins: [plugin],
+    });
+    const fn = jest.fn(() => {
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+    return new Promise((resolve) => {
+      const watcher = compiler.watch({}, fn);
+      setTimeout(() => {
+        watcher.close(resolve);
+      }, 500);
+    });
+  });
+
+  it('should compile once in build mode', async () => {
+    const plugin = new Plugin({
+      'entry.js': 'console.log("build once");',
+    });
+    const compiler = webpack({
+      entry: './entry.js',
+      plugins: [plugin],
+    });
+    const fn = jest.fn(() => {
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+    return new Promise<void>((resolve) => {
+      compiler.run(fn);
+      setTimeout(() => {
+        resolve();
+      }, 500);
+    });
+  });
+
   const version = (webpack.version && parseInt(webpack.version.split('.')[0])) || 0;
 
   (version >= 4 ? it : it.skip)('should NOT rebuild all virtual modules on any change', async () => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

When webpack-virtual-modules is executed in watch mode, the watch handle will be executed twice.

```js
  it('should compile once in watch mode', async () => {
    const plugin = new Plugin({
      'entry.js': 'console.log("build once");',
    });
    const compiler = webpack({
      entry: './entry.js',
      plugins: [plugin],
    });
    const fn = jest.fn(() => {
      expect(fn).toHaveBeenCalledTimes(1);
    });
    return new Promise((resolve) => {
      const watcher = compiler.watch({}, fn);
      setTimeout(() => {
        watcher.close(resolve);
      }, 500);
    });
  });
```
No any entries have been changed,but it calls twice.

```bash
  ● webpack-virtual-modules › should compile once in watch mode

    expect(jest.fn()).toHaveBeenCalledTimes(expected)

    Expected number of calls: 1
    Received number of calls: 2

      232 |     });
      233 |     const fn = jest.fn(() => {
    > 234 |       expect(fn).toHaveBeenCalledTimes(1);
          |                  ^
      235 |     });
      236 |     return new Promise((resolve) => {
      237 |       const watcher = compiler.watch({}, fn);
```

