### PR TITLE
feat: add possibility to get modules

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,12 +21,20 @@ describe('webpack-virtual-modules', () => {
     expect(() => plugin.writeModule('example.js', '')).not.toThrow();
   });
 
+  it('should return static modules', async () => {
+    const options = { 'static_module1.js': 'const foo;' };
+    options[path.resolve('static_module2.js')] = 'const bar;';
+    const plugin = new Plugin(options);
+
+    expect(plugin.getModules()).toMatchObject(options);
+  });
+
   it('should write static modules to fs', async () => {
     const options = { 'static_module1.js': 'const foo;' };
     options[path.resolve('static_module2.js')] = 'const bar;';
     const plugin = new Plugin(options);
 
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       webpack({
         plugins: [plugin],
         entry: './entry.js',
@@ -46,7 +54,7 @@ describe('webpack-virtual-modules', () => {
       'static_module.js': 'const foo;',
     });
 
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       webpack({
         plugins: [plugin],
         entry: './entry.js',
@@ -64,7 +72,7 @@ describe('webpack-virtual-modules', () => {
   it('purge should work when no virtual files exist', async () => {
     const plugin = new Plugin();
 
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       webpack({
         plugins: [plugin],
         entry: './entry.js',
@@ -90,7 +98,7 @@ describe('webpack-virtual-modules', () => {
       entry: './entry.js',
     });
 
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       compiler.run((err, stats) => {
         if (!stats) throw err;
 
@@ -198,7 +206,7 @@ describe('webpack-virtual-modules', () => {
     const fileSystem = new MemoryFileSystem();
     compiler.outputFileSystem = fileSystem;
 
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       compiler.run((err, stats) => {
         expect(stats).toBeDefined();
         expect(err).toBeNull();
@@ -247,6 +255,7 @@ describe('webpack-virtual-modules', () => {
     // support mode: development
     // left for future testing and possibility of enabling test for it
     if (webpack.version && typeof webpack.version === 'string') {
+      // @ts-ignore TODO: It's enough?
       config.mode = 'development';
     }
     const compiler = webpack(config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,10 @@ class VirtualModulesPlugin {
     this._staticModules = modules || null;
   }
 
+  public getModules() {
+    return this._staticModules;
+  }
+
   public writeModule(filePath: string, contents: string): void {
     if (!this._compiler) {
       throw new Error(`Plugin has not been initialized`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,11 @@ import { VirtualStats } from './virtual-stats';
 import type { Compiler } from 'webpack';
 
 let inode = 45000000;
+const ALL = 'all';
+const STATIC = 'static';
+const DYNAMIC = 'dynamic';
+
+type AvailableModules = typeof ALL | typeof STATIC | typeof DYNAMIC;
 
 function checkActivation(instance) {
   if (!instance._compiler) {
@@ -105,8 +110,36 @@ class VirtualModulesPlugin {
     this._staticModules = modules || null;
   }
 
-  public getModules() {
-    return this._staticModules;
+  public getModuleList(filter: AvailableModules = ALL) {
+    let modules = {};
+    const shouldGetStaticModules = filter === ALL || filter === STATIC;
+    const shouldGetDynamicModules = filter === ALL || filter === DYNAMIC;
+
+    if (shouldGetStaticModules) {
+      // Get static modules
+      modules = {
+        ...modules,
+        ...this._staticModules,
+      };
+    }
+
+    if (shouldGetDynamicModules) {
+      // Get dynamic modules
+      const finalInputFileSystem: any = this._compiler?.inputFileSystem;
+      const virtualFiles = finalInputFileSystem?._virtualFiles ?? {};
+
+      const dynamicModules: Record<string, string> = {};
+      Object.keys(virtualFiles).forEach((key: string) => {
+        dynamicModules[key] = virtualFiles[key].contents;
+      });
+
+      modules = {
+        ...modules,
+        ...dynamicModules,
+      };
+    }
+
+    return modules;
   }
 
   public writeModule(filePath: string, contents: string): void {


### PR DESCRIPTION
**What's the problem this PR addresses?**
I needed to access the static modules multiple times. As shown in the links, people require them.

https://github.com/module-federation/universe/blob/main/packages/storybook-addon/src/lib/storybook-addon.ts#L81
https://github.com/nuxt-modules/storybook/blob/95cd445eed0cdc570bbfba03ff9589c727a41ee8/src/webpack.ts#L32C99-L32C99
...

**How did you fix it?**
A new method has been added to retrieve static modules.
...
