### PR TITLE
chore: check finalWatchFileSystem.watcher nullability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,7 @@ class VirtualModulesPlugin {
     finalInputFileSystem._writeVirtualFile(modulePath, stats, contents);
     if (
       finalWatchFileSystem &&
+      finalWatchFileSystem.watcher &&
       (finalWatchFileSystem.watcher.fileWatchers.size || finalWatchFileSystem.watcher.fileWatchers.length)
     ) {
       const fileWatchers =


### PR DESCRIPTION
In this PR, I have added a check for the nullability of `finalWatchFileSystem.watcher`

#### Background
This library is used by the development server that starts up during Gatsby development.

Gatsby features a function named DEV_SSR, which makes it easier to detect SSR errors during development. However, when this feature is enabled in our environment and an actual SSR error occurs, the development server itself shuts down due to the following error in this library:

```
Cannot read properties of null (reading 'fileWatchers')
```

This prevents us from verifying the content of the SSR error, defeating the purpose of the DEV_SSR feature. While I have not fully investigated why `finalWatchFileSystem.watcher` becomes null, I believe that the modification proposed in this PR will not have any adverse effects. I would appreciate it if you could consider merging this change.
